### PR TITLE
Updating Branch 0.6.x to use Gulp 4 syntax

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,12 +3,13 @@ var babel = require('gulp-babel');
 var nodemon = require('gulp-nodemon');
 var browserify = require('browserify');
 var source = require('vinyl-source-stream');
-var sequence = require('run-sequence');
+
 
 gulp.task('copy', function () {
   return gulp.src('src/**/*.html')
     .pipe(gulp.dest('dist'));
 });
+
 
 gulp.task('compile', function () {
   return gulp.src('src/**/*.js')
@@ -18,10 +19,13 @@ gulp.task('compile', function () {
     .pipe(gulp.dest('dist'));
 });
 
-gulp.task('watch', function () {
-  gulp.watch('src/**/*.js', ['compile', 'bundle'])
-  gulp.watch('src/**/*.html', ['copy']);
+
+gulp.task('watch', function (cb) {
+  gulp.watch('src/**/*.js', gulp.series('compile','bundle'))
+  gulp.watch('src/**/*.html', gulp.series('copy'));
+  cb();
 });
+
 
 gulp.task('bundle', function () {
   var b = browserify({
@@ -35,6 +39,7 @@ gulp.task('bundle', function () {
     .pipe(gulp.dest('dist'));
 });
 
+
 gulp.task('start', function () {
   nodemon({
     watch: 'dist',
@@ -44,6 +49,9 @@ gulp.task('start', function () {
   });
 });
 
-gulp.task('default', function (callback) {
-  sequence(['compile', 'watch', 'copy', 'bundle'], 'start', callback);
+
+gulp.task('default', function (){ 
+  return gulp.series( 
+          gulp.parallel('compile', 'watch', 'copy','bundle'),
+           'start')();
 });

--- a/package.json
+++ b/package.json
@@ -33,13 +33,12 @@
     "babel-preset-es2015": "^6.6.0",
     "babelify": "^7.2.0",
     "browserify": "^11.0.1",
-    "gulp": "^3.9.0",
+    "gulp": "^4.0.0",
     "gulp-babel": "^6.1.2",
     "gulp-concat": "^2.6.0",
     "gulp-nodemon": "^2.0.3",
     "gulp-nunjucks": "^1.0.3",
-    "run-sequence": "^1.1.2",
-    "vinyl-source-stream": "^1.1.0"
+    "vinyl-source-stream": "^2.0.0"
   },
   "browser": {
     "./src/lib/index.js": "./src/lib/index.client.js",


### PR DESCRIPTION
I updated the gulp files to work with gulp 4, i figured most people would be using that by now. And run-sequence can be replaced with gulp.series and gulp.parallel and I updated the vinyl-source-streams package too